### PR TITLE
skip unsupported dcm + fix one frame image orientation

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -5,3 +5,6 @@ supervisely[apps]==6.72.122
 gdcm==1.1
 pylibjpeg==1.4.0
 pylibjpeg-libjpeg==1.3.1
+
+
+scikit-image

--- a/local.env
+++ b/local.env
@@ -2,14 +2,14 @@ PYTHONUNBUFFERED=1
 
 LOG_LEVEL="debug"
 
-TASK_ID=31840
+TASK_ID=45713
 
-CONTEXT_TEAMID=449
-CONTEXT_WORKSPACEID=691
+CONTEXT_TEAMID=452
+CONTEXT_WORKSPACEID=696
 
 # modal.state.slyFolder="agent://266/min_cardio/"
 # modal.state.slyFolder="/min_cardio/"
-modal.state.slyFolder="/19399_cardio/"
+modal.state.slyFolder="/dicom_studies_1/"
 # modal.state.slyFolder="/my_project/cardio/"
 
 # modal.state.slyFile="agent://160/import-studies/my_project.zip"

--- a/src/main.py
+++ b/src/main.py
@@ -34,9 +34,16 @@ def import_dicom_studies(
 
     ds_progress = sly.Progress(message="Importing Datasets", total_cnt=len(datasets_paths))
     for dataset_path in datasets_paths:
-        f.import_dataset(api, dataset_path)
+        try:
+            f.import_dataset(api, dataset_path)
+        except FileNotFoundError as e:
+            if str(e) == "Nothing to import":
+                sly.logger.warning(f"Skipping dataset '{dataset_path}', nothing to import")
+                continue
         ds_progress.iter_done_report()
-
+    if api.project.get_datasets_count(project.id) == 0:
+        api.project.remove(project.id)
+        sly.logger.warning("The project has no datasets and will be removed from workspace")
     g.my_app.stop()
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -43,7 +43,9 @@ def import_dicom_studies(
         ds_progress.iter_done_report()
     if api.project.get_datasets_count(project.id) == 0:
         api.project.remove(project.id)
-        sly.logger.warning("The project has no datasets and will be removed from workspace")
+        sly.logger.warning(
+            f"The project '{project.name}' has no datasets and will be removed from workspace"
+        )
     g.my_app.stop()
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,8 @@ import supervisely as sly
 import sly_globals as g
 import sly_utils as f
 
+from supervisely.io.fs import remove_dir
+
 
 @g.my_app.callback("import-dicom-studies")
 @sly.timeit
@@ -46,6 +48,7 @@ def import_dicom_studies(
         sly.logger.warning(
             f"The project '{project.name}' has no datasets and will be removed from workspace"
         )
+    remove_dir(project_dir)
     g.my_app.stop()
 
 

--- a/src/sly_utils.py
+++ b/src/sly_utils.py
@@ -364,6 +364,9 @@ def dcm2nrrd(
     if len(dcm.pixel_array.shape) == 3:
         if dcm.pixel_array.shape[0] == 1 and not hasattr(dcm, "NumberOfFrames"):
             frames = 1
+            pixel_data_list = [
+                dcm.pixel_array.reshape((dcm.pixel_array.shape[1], dcm.pixel_array.shape[2]))
+            ]
             header = get_nrrd_header(image_path)
         else:
             try:

--- a/src/sly_utils.py
+++ b/src/sly_utils.py
@@ -362,15 +362,19 @@ def dcm2nrrd(
     pixel_data_list = [dcm.pixel_array]
 
     if len(dcm.pixel_array.shape) == 3:
-        try:
-            frames = int(dcm.NumberOfFrames)
-        except AttributeError as e:
-            if str(e) == "'FileDataset' object has no attribute 'NumberOfFrames'":
-                e.args = ("can't get 'NumberOfFrames' from dcm meta.",)
-                raise e
-        frame_axis = find_frame_axis(dcm.pixel_array, frames)
-        pixel_data_list, frame_axis = create_pixel_data_set(dcm, frame_axis)
-        header = get_nrrd_header(image_path, frame_axis)
+        if dcm.pixel_array.shape[0] == 1 and not hasattr(dcm, "NumberOfFrames"):
+            frames = 1
+            header = get_nrrd_header(image_path)
+        else:
+            try:
+                frames = int(dcm.NumberOfFrames)
+            except AttributeError as e:
+                if str(e) == "'FileDataset' object has no attribute 'NumberOfFrames'":
+                    e.args = ("can't get 'NumberOfFrames' from dcm meta.",)
+                    raise e
+            frame_axis = find_frame_axis(dcm.pixel_array, frames)
+            pixel_data_list, frame_axis = create_pixel_data_set(dcm, frame_axis)
+            header = get_nrrd_header(image_path, frame_axis)
     elif len(dcm.pixel_array.shape) == 2:
         frames = 1
         header = get_nrrd_header(image_path)

--- a/src/sly_utils.py
+++ b/src/sly_utils.py
@@ -45,10 +45,15 @@ def import_images(
     anns = []
 
     for image_path, annotation_path in zip(batch_imgs, batch_anns):
-        image_paths, image_names, anns_from_dcm = dcm2nrrd(
-            image_path=image_path,
-            group_tag_name=g.GROUP_TAG_NAME,
-        )
+        try:
+            image_paths, image_names, anns_from_dcm = dcm2nrrd(
+                image_path=image_path,
+                group_tag_name=g.GROUP_TAG_NAME,
+            )
+        except Exception as e:
+            sly.logger.warning(f"File '{image_path}' will be skipped due to: {str(e)}")
+            continue
+
         img_paths.extend(image_paths)
         img_names.extend(image_names)
 
@@ -60,6 +65,10 @@ def import_images(
             anns.append(ann)
         else:
             anns.extend(anns_from_dcm)
+
+    if len(img_paths) == 0:
+        api.dataset.remove(dataset.id)
+        raise FileNotFoundError("Nothing to import")
 
     # Upload the images and annotations to the project
     dst_image_infos = api.image.upload_paths(
@@ -355,16 +364,20 @@ def dcm2nrrd(
     if len(dcm.pixel_array.shape) == 3:
         try:
             frames = int(dcm.NumberOfFrames)
-        except Exception:
-            raise NotImplementedError(
-                f"Can't get frames from dcm meta. This type of data is not supported"
-            )
+        except AttributeError as e:
+            if str(e) == "'FileDataset' object has no attribute 'NumberOfFrames'":
+                e.args = ("can't get 'NumberOfFrames' from dcm meta.",)
+                raise e
         frame_axis = find_frame_axis(dcm.pixel_array, frames)
         pixel_data_list, frame_axis = create_pixel_data_set(dcm, frame_axis)
         header = get_nrrd_header(image_path, frame_axis)
-    else:
+    elif len(dcm.pixel_array.shape) == 2:
         frames = 1
         header = get_nrrd_header(image_path)
+    else:
+        raise NotImplementedError(
+            f"this type of dcm data is not supported, pixel_array.shape = {len(dcm.pixel_array.shape)}"
+        )
 
     save_paths = []
     image_names = []

--- a/src/sly_utils.py
+++ b/src/sly_utils.py
@@ -393,6 +393,7 @@ def dcm2nrrd(
 
         if frames == 1:
             pixel_data = sly.image.rotate(img=pixel_data, degrees_angle=270)
+            pixel_data = sly.image.fliplr(pixel_data)
             image_name = f"{original_name}.nrrd"
         else:
             pixel_data = np.squeeze(pixel_data, frame_axis)


### PR DESCRIPTION
- fix one frame image orientation
- add import of shapes(1, h, w) 
- exclude files that doesn't correspond requirements from dataset
- log warn message with explanation of skipped files
- remove empty dataset if no files imported
- remove project from workspace if no datasets imported
- add additional data directory cleanup before application shutdown

